### PR TITLE
OEL-1668: Constrain prophecy-phpunit to version 2.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "openeuropa/code-review": "^1.6 || ^2.0",
         "openeuropa/oe_content": "^2.8.0",
         "openeuropa/task-runner-drupal-project-symlink": "^1.0.0-beta5",
-        "phpspec/prophecy-phpunit": "^1 || ^2"
+        "phpspec/prophecy-phpunit": "^2"
     },
     "scripts": {
         "post-install-cmd": "./vendor/bin/run drupal:site-setup",


### PR DESCRIPTION
Scope is to resolve this issue https://drone.fpfis.eu/openeuropa/oe_content_extra/63/12